### PR TITLE
Store search query into cookie 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite src",
-		"build": "vite build src",
+		"build": "vite build src --emptyOutDir",
 		"preview": "vite preview src",
 		"lint": "eslint . --fix"
 	},

--- a/src/index.html
+++ b/src/index.html
@@ -38,6 +38,41 @@
 		<main class="content">
 			<section id="articles-container" class="videos-container container">
 
+				<!-- video card template -->
+				<template id="video-template">
+					<article class="video template-2">
+						<a
+							href=""
+							target="_blank"
+							referrerpolicy="no-referrer"
+							class="url"
+						>
+							<div class="video-image">
+								<!-- Video image -->
+								<div class="video-image-container">
+									<img class="img-video"
+										src=""
+										alt="youtube thumbnail" />
+									<!-- Play button container -->
+									<div class="video-play">
+										<img src="icons/play-icon.svg" alt="" />
+									</div>
+								</div>
+							</div>
+						</a>
+						<h2 class="video-title">
+							<a
+								href=""
+								target="_blank"
+								referrerpolicy="no-referrer"
+								class="title"
+								>
+							</a>
+						</h2>
+						<div class="video-tags"></div>
+					</article>
+				</template>
+
 			</section>
 		</main>
 		<script type="module" src="/script.js"></script>

--- a/src/script.js
+++ b/src/script.js
@@ -1,3 +1,5 @@
+import SearchHistory from "./storage.js";
+
 // dark and light
 const icon = document.getElementById('icon');
 // selecting form
@@ -27,11 +29,14 @@ loading();
 async function searchingVideos (e) {
 	e.preventDefault();
 
+	const formEntries = Object.fromEntries(new FormData(formulario));
+	const searchTerm = formEntries["search-criteria"];
+
 	//requesting key of search
 	const responseKey = await fetch('http://localhost:9090/search', {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify(Object.fromEntries(new FormData(formulario))),
+		body: JSON.stringify(formEntries),
 	});
 
 	//dataKey will be sended in the body of next request
@@ -107,6 +112,15 @@ async function searchingVideos (e) {
 							</div>
 						</article>
 						`;
+
+
+					// click listener
+					const newVideo   = section.children[section.childElementCount-1];
+					const titleAncle = newVideo.querySelector(".title");
+					titleAncle.addEventListener("click", ()=>{
+						SearchHistory.saveEntry(searchTerm);
+					});
+
 				});
 			} else {
 				loading();

--- a/src/script.js
+++ b/src/script.js
@@ -89,7 +89,6 @@ async function searchingVideos(e) {
 					const ancles = newVideo.getElementsByTagName("a");
 					for (const a of ancles){
 						a.addEventListener("click", ()=>{
-							console.log("mmi");
 							SearchHistory.saveEntry(searchTerm);
 						});
 					}

--- a/src/script.js
+++ b/src/script.js
@@ -1,11 +1,9 @@
 import SearchHistory from "./storage.js";
 
-// dark and light
 const icon = document.getElementById('icon');
-// selecting form
 const formulario = document.getElementById('formulario');
-// selectin icon-search
 const search = document.getElementById('search-icon');
+const videoTemplate = document.getElementById('video-template');
 
 // initializing var of intervalID for future work
 let intervalID = -1;
@@ -38,7 +36,7 @@ async function searchingVideos(e) {
 	const searchTerm = formEntries["search-criteria"];
 
 	//requesting key of search
-	const responseKey = await fetch('http://localhost:9090/search', {
+	const responseKey = await fetch('http://192.168.1.6:9090/search', {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify(formEntries),
@@ -49,7 +47,7 @@ async function searchingVideos(e) {
 
 	//requesting videos
 	intervalID = setInterval(async () => {
-		const responseVid = await fetch('http://localhost:9090/result/obtain', {
+		const responseVid = await fetch('http://192.168.1.6:9090/result/obtain', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({ key: dataKey.uuid }),
@@ -85,7 +83,16 @@ async function searchingVideos(e) {
 						auxTags += `<p class="video-tag">${element}</p>`;
 					});
 
-					section.innerHTML += createCard(element, auxTags);
+					const newVideo = section.appendChild(createCard(element, auxTags));
+
+					// click listener
+					const ancles = newVideo.getElementsByTagName("a");
+					for (const a of ancles){
+						a.addEventListener("click", ()=>{
+							console.log("mmi");
+							SearchHistory.saveEntry(searchTerm);
+						});
+					}
 				});
 			}
 		}
@@ -121,38 +128,12 @@ function loading() {
 }
 
 function createCard(video, tags) {
-	return `
-		<article class="video template-2">
-			<a
-				href="${video.url}"
-				target="_blank"
-				referrerpolicy="no-referrer"
-				class="url"
-			>
-				<div class="video-image">
-					<!-- Video image -->
-					<div class="video-image-container">
-						<img class="img-video" src="${video.thumbnail}" alt="${video.title} youtube thumbnail" />
-						<!-- Play button container -->
-						<div class="video-play">
-							<img src="icons/play-icon.svg" alt="" />
-						</div>
-					</div></div
-			></a>
-
-			<h2 class="video-title">
-				<a
-					href="${video.url}"
-					target="_blank"
-					referrerpolicy="no-referrer"
-					class="title"
-					>${video.title}</a
-				>
-			</h2>
-
-			<div class="video-tags">
-				${tags}
-			</div>
-		</article>
-	`;
+	let newv = videoTemplate.content.firstElementChild.cloneNode(true);
+	newv.querySelector(".url").href      = video.url;
+	newv.querySelector(".img-video").src = video.thumbnail;
+	newv.querySelector(".img-video").alt = video.title;
+	newv.querySelector(".title").href    = video.url;
+	newv.querySelector(".title").textContent    = video.title;
+	newv.querySelector(".video-tags").innerHTML = tags;
+	return newv;
 }

--- a/src/script.js
+++ b/src/script.js
@@ -36,7 +36,7 @@ async function searchingVideos(e) {
 	const searchTerm = formEntries["search-criteria"];
 
 	//requesting key of search
-	const responseKey = await fetch('http://192.168.1.6:9090/search', {
+	const responseKey = await fetch('http://localhost:9090/search', {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify(formEntries),
@@ -47,7 +47,7 @@ async function searchingVideos(e) {
 
 	//requesting videos
 	intervalID = setInterval(async () => {
-		const responseVid = await fetch('http://192.168.1.6:9090/result/obtain', {
+		const responseVid = await fetch('http://localhost:9090/result/obtain', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({ key: dataKey.uuid }),

--- a/src/storage.js
+++ b/src/storage.js
@@ -22,7 +22,7 @@ export default class SearchHistory{
 	// saves a new history
 	static saveEntry(entry){
 		const hist = SearchHistory.getAll().entries;
-		hist.push(entry);
+		hist.push(entry.toLowerCase());
 
 		// unique entries
 		const newHist = hist.filter((item, index) => hist.indexOf(item) === index);
@@ -31,6 +31,7 @@ export default class SearchHistory{
 		}
 
 		// save cookie
-		document.cookie = JSON.stringify(cookie);
+		document.cookie = JSON.stringify(cookie) +
+			"; SameSite=Strict; expires=Tue, 19 Jan 2038 03:14:07 UTC";
 	}
 }

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,36 @@
+export default class SearchHistory{
+	constructor(){
+	}
+
+	// returns history if found, empty history otherwise
+	static getAll(){
+		let history;
+		const savedCookies = document.cookie;
+
+		if (!savedCookies){
+			history = {
+				entries: []
+			};
+		}
+		else{
+			history = JSON.parse(savedCookies);
+		}
+
+		return history;
+	}
+
+	// saves a new history
+	static saveEntry(entry){
+		const hist = SearchHistory.getAll().entries;
+		hist.push(entry);
+
+		// unique entries
+		const newHist = hist.filter((item, index) => hist.indexOf(item) === index);
+		const cookie = {
+			entries: newHist
+		}
+
+		// save cookie
+		document.cookie = JSON.stringify(cookie);
+	}
+}


### PR DESCRIPTION
Depende de #17 
- Se guardan en el historial aquellos términos de búsqueda cuyos resultados el usuario haya clickeado.
- Se asegura que no hayan entradas repetidas.
- Momentáneamente no tiene limite; de esto @andres123dbh se encargará.
## Update
- Se reemplaza el método de agregar cartas con innerHTML, puesto que modificar este valor vuelve a crear todos los elementos hijo, entonces los eventos previamente agregados también se pierden. En su lugar se usó un template clonable.
- Ahora clickear en la imagen también cuenta.